### PR TITLE
Fix hamburger overlay order and mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,40 +34,42 @@
         class="container mx-auto flex flex-col md:flex-row gap-3 md:gap-4 md:items-center justify-between"
       >
         <!-- Title/Brand Area -->
-        <div class="flex items-center gap-3 self-start md:self-center">
+        <div class="flex items-center gap-3 self-center">
           <h1 class="title text-lg md:text-xl tracking-tight">DS</h1>
           <div class="h-4 md:h-5 w-px bg-black"></div>
           <span class="mono text-xs">MATHÉMATIQUES</span>
         </div>
 
-        <!-- Barre de recherche minimaliste -->
-        <!-- Takes full width on mobile, constrained on md+ -->
-        <div
-          class="search-container w-full md:flex-1 relative md:mx-12 md:max-w-xl order-3 md:order-2"
-        >
-          <!-- Wrapper for input and clear button -->
-          <div class="search-input-wrapper">
-            <input
-              type="text"
-              id="search"
-              placeholder="rechercher un ds..."
-              class="w-full px-3 search-input"
-              autocomplete="off"
-            />
-            <!-- Clear button -->
-            <span id="clear-search-btn" class="clear-search-btn">
-              <i class="fas fa-times text-xs"></i>
-            </span>
+        <!-- Search bar and menu button -->
+        <div class="flex items-center w-full gap-3 order-2 md:order-2">
+          <!-- Barre de recherche minimaliste -->
+          <div
+            class="search-container flex-grow relative md:mx-12 md:max-w-xl"
+          >
+            <!-- Wrapper for input and clear button -->
+            <div class="search-input-wrapper">
+              <input
+                type="text"
+                id="search"
+                placeholder="rechercher un ds..."
+                class="w-full px-3 search-input"
+                autocomplete="off"
+              />
+              <!-- Clear button -->
+              <span id="clear-search-btn" class="clear-search-btn">
+                <i class="fas fa-times text-xs"></i>
+              </span>
+            </div>
+            <div id="search-suggestions" class="search-suggestions"></div>
           </div>
-          <div id="search-suggestions" class="search-suggestions"></div>
-        </div>
 
-        <!-- Hamburger Menu -->
-        <div class="hamburger order-2 md:order-3">
-          <div class="hamburger__container">
-            <span class="hamburger__top"></span>
-            <span class="hamburger__middle"></span>
-            <span class="hamburger__bottom"></span>
+          <!-- Hamburger Menu -->
+          <div class="hamburger">
+            <div class="hamburger__container">
+              <span class="hamburger__top"></span>
+              <span class="hamburger__middle"></span>
+              <span class="hamburger__bottom"></span>
+            </div>
           </div>
         </div>
       </div>

--- a/menu.css
+++ b/menu.css
@@ -52,62 +52,6 @@
         --transition: cubic-bezier(0.77, 0, 0.175, 1);
       }
 
-      /* -------------------------------------------------- */
-      /* Brutalist Hamburger                                */
-      /* -------------------------------------------------- */
-      .hamburger {
-        position: fixed;
-        top: 2rem;
-        right: 2rem;
-        z-index: 1000;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 3rem;
-        width: 3rem;
-        border: var(--line-weight) solid var(--color-ink);
-        cursor: pointer;
-        background: var(--color-paper);
-        transition: all 0.3s var(--transition);
-        -webkit-backdrop-filter: blur(20px);
-        backdrop-filter: blur(20px);
-      }
-
-      .hamburger:hover {
-        background: var(--color-surface);
-      }
-
-      .hamburger__container {
-        position: relative;
-        transition: transform 0.3s var(--transition);
-      }
-
-      .hamburger__top,
-      .hamburger__middle,
-      .hamburger__bottom {
-        display: block;
-        width: 1.2rem;
-        height: var(--line-weight);
-        background: var(--color-ink);
-        transition: all 0.3s var(--transition);
-        transform-origin: center;
-      }
-
-      .hamburger__middle {
-        margin: 4px 0;
-      }
-
-      /* Cross state */
-      .js-menu-open .hamburger__top {
-        transform: translateY(5px) rotate(45deg);
-      }
-      .js-menu-open .hamburger__middle {
-        opacity: 0;
-        transform: scale(0);
-      }
-      .js-menu-open .hamburger__bottom {
-        transform: translateY(-5px) rotate(-45deg);
-      }
 
       /* -------------------------------------------------- */
       /* Menu overlay                                       */
@@ -334,7 +278,9 @@
         transform: translateY(10px);
         transition: all 0.8s var(--transition);
         padding: 0.3rem 0;
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
       }
 
       .menu__link:hover {
@@ -467,8 +413,5 @@
           display: none;
         }
 
-        .hamburger {
-          top: 1rem;
-          right: 1rem;
-        }
+        /* Hamburger button is styled in styles.css */
       }

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,7 @@
   --color-facile: rgba(0, 150, 100, 0.85);
   --color-moyen: rgba(150, 120, 0, 0.85);
   --color-difficile: rgba(150, 30, 30, 0.85);
+  --transition: cubic-bezier(0.77, 0, 0.175, 1);
 }
 
 /* STRUCTURE DE BASE */
@@ -102,10 +103,62 @@ h3,
   border-bottom: var(--line-weight) solid var(--color-ink);
   position: sticky;
   top: 0;
-  z-index: 50;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   background-color: rgba(252, 252, 252, 0.8);
+}
+
+/* Hamburger button */
+.hamburger {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border: var(--line-weight) solid var(--color-ink);
+  cursor: pointer;
+  background: var(--color-paper);
+  transition: all 0.3s var(--transition);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  z-index: 1002; /* Above menu overlay */
+}
+
+.hamburger:hover {
+  background: var(--color-surface);
+}
+
+.hamburger__container {
+  position: relative;
+  transition: transform 0.3s var(--transition);
+}
+
+.hamburger__top,
+.hamburger__middle,
+.hamburger__bottom {
+  display: block;
+  width: 1.2rem;
+  height: var(--line-weight);
+  background: var(--color-ink);
+  transition: all 0.3s var(--transition);
+  transform-origin: center;
+}
+
+.hamburger__middle {
+  margin: 4px 0;
+}
+
+/* Cross state */
+.js-menu-open .hamburger__top {
+  transform: translateY(5px) rotate(45deg);
+}
+.js-menu-open .hamburger__middle {
+  opacity: 0;
+  transform: scale(0);
+}
+.js-menu-open .hamburger__bottom {
+  transform: translateY(-5px) rotate(-45deg);
 }
 
 /* BARRE DE RECHERCHE */


### PR DESCRIPTION
## Summary
- center brand text in header
- keep search bar and hamburger on one line on mobile
- remove header stacking context so hamburger stays above the overlay

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_686fc07fac28833294b34934fc810375